### PR TITLE
Add Dnspod script to Hosts.sgmodule

### DIFF
--- a/Module/Hosts.sgmodule
+++ b/Module/Hosts.sgmodule
@@ -1464,3 +1464,6 @@ zc.adpush.cn = 127.0.0.1
 z.domob.cn = 127.0.0.1
 z.sora.yoyi.com.cn = 127.0.0.1
 zt.adsage.com = 127.0.0.1
+
+[Script]
+Dnspod = type=dns,script-path=https://raw.githubusercontent.com/maicoo-l/Surge/master/Script/dnspod.js


### PR DESCRIPTION
Hosts.sgmodule中对App Store相关域名使用了Dnspod脚本加速下载，故在模块中加入Dnspod script。